### PR TITLE
add optional command line argument for skaffold build

### DIFF
--- a/skaffold-build/action.yml
+++ b/skaffold-build/action.yml
@@ -5,6 +5,10 @@ inputs:
     default: ""
     description: 'Repo to push images to or empty string to disable push'
     required: false
+  skaffold_file_path:
+    default: ""
+    description: 'Path to a skaffold.yaml file'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/skaffold-build/entrypoint.sh
+++ b/skaffold-build/entrypoint.sh
@@ -8,4 +8,9 @@ else
   export SKAFFOLD_DEFAULT_REPO=$INPUT_DEFAULT_REPO
 fi
 
-skaffold build
+if [ -z $INPUT_SKAFFOLD_FILE_PATH ]
+then
+  skaffold build
+else
+  skaffold build -f $INPUT_SKAFFOLD_FILE_PATH
+fi


### PR DESCRIPTION
Add optional command input argument for skaffold build. This is relevant for the springtrader cache pipeline where we have to run `skaffold build -f ./.cache/skaffold.yaml`