### PR TITLE
Update ECR and helm push

### DIFF
--- a/ecr/Dockerfile
+++ b/ecr/Dockerfile
@@ -1,8 +1,8 @@
 FROM docker:18.09
 
 RUN apk update && \
-apk -Uuv add python py-pip && \
-pip install awscli boto3
+apk -Uuv add python3 py3-pip && \
+pip3 install awscli boto3
 
 COPY create-repos.py /create-repos.py
 COPY entrypoint.sh /entrypoint.sh

--- a/ecr/create-repos.py
+++ b/ecr/create-repos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import yaml
 import json
 import boto3

--- a/helm-push/Dockerfile
+++ b/helm-push/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache bash git curl jq
 ENV XDG_DATA_HOME /root/.local/share
 ENV HELM_HOME ${XDG_DATA_HOME}/helm
 
-RUN helm2 init --client-only
+RUN helm2 init --client-only --stable-repo-url "https://charts.helm.sh/stable"
 
 RUN curl -Ls https://github.com/steven-sheehy/helm-s3/releases/download/v0.9.0/helm-s3_0.9.0_linux_amd64.tar.gz -o /tmp/helm-s3.tar.gz \
     && mkdir -p ${HELM_HOME}/plugins/helm-s3 \

--- a/helm-push/Dockerfile
+++ b/helm-push/Dockerfile
@@ -6,10 +6,11 @@ ENV XDG_DATA_HOME /root/.local/share
 ENV HELM_HOME ${XDG_DATA_HOME}/helm
 ENV HELM_S3_MODE 3
 
-RUN curl -Ls https://github.com/steven-sheehy/helm-s3/releases/download/v0.9.0/helm-s3_0.9.0_linux_amd64.tar.gz -o /tmp/helm-s3.tar.gz \
-    && mkdir -p ${HELM_HOME}/plugins/helm-s3 \
-    && tar xzf /tmp/helm-s3.tar.gz -C ${HELM_HOME}/plugins/helm-s3 \
-    && rm /tmp/helm-s3.tar.gz
+##RUN https://github.com/steven-sheehy/helm-s3/releases/download/v0.9.0/helm-s3_0.9.0_linux_amd64.tar.gz -o /tmp/helm-s3.tar.gz \
+#    && mkdir -p ${HELM_HOME}/plugins/helm-s3 \
+#    && tar xzf /tmp/helm-s3.tar.gz -C ${HELM_HOME}/plugins/helm-s3 \
+#    && rm /tmp/helm-s3.tar.gz
+RUN helm plugin install https://github.com/hypnoglow/helm-s3.git --version 0.10.0
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/helm-push/Dockerfile
+++ b/helm-push/Dockerfile
@@ -4,6 +4,7 @@ RUN apk add --no-cache bash git curl jq
 
 ENV XDG_DATA_HOME /root/.local/share
 ENV HELM_HOME ${XDG_DATA_HOME}/helm
+ENV HELM_S3_MODE 3
 
 RUN curl -Ls https://github.com/steven-sheehy/helm-s3/releases/download/v0.9.0/helm-s3_0.9.0_linux_amd64.tar.gz -o /tmp/helm-s3.tar.gz \
     && mkdir -p ${HELM_HOME}/plugins/helm-s3 \

--- a/helm-push/Dockerfile
+++ b/helm-push/Dockerfile
@@ -6,10 +6,6 @@ ENV XDG_DATA_HOME /root/.local/share
 ENV HELM_HOME ${XDG_DATA_HOME}/helm
 ENV HELM_S3_MODE 3
 
-##RUN https://github.com/steven-sheehy/helm-s3/releases/download/v0.9.0/helm-s3_0.9.0_linux_amd64.tar.gz -o /tmp/helm-s3.tar.gz \
-#    && mkdir -p ${HELM_HOME}/plugins/helm-s3 \
-#    && tar xzf /tmp/helm-s3.tar.gz -C ${HELM_HOME}/plugins/helm-s3 \
-#    && rm /tmp/helm-s3.tar.gz
 RUN helm plugin install https://github.com/hypnoglow/helm-s3.git --version 0.10.0
 
 COPY entrypoint.sh /entrypoint.sh

--- a/helm-push/Dockerfile
+++ b/helm-push/Dockerfile
@@ -1,13 +1,9 @@
 FROM alpine/helm:3.1.2
 
-COPY --from=alpine/helm:2.12.2 /usr/bin/helm /usr/bin/helm2
-
 RUN apk add --no-cache bash git curl jq
 
 ENV XDG_DATA_HOME /root/.local/share
 ENV HELM_HOME ${XDG_DATA_HOME}/helm
-
-RUN helm2 init --client-only --stable-repo-url "https://charts.helm.sh/stable"
 
 RUN curl -Ls https://github.com/steven-sheehy/helm-s3/releases/download/v0.9.0/helm-s3_0.9.0_linux_amd64.tar.gz -o /tmp/helm-s3.tar.gz \
     && mkdir -p ${HELM_HOME}/plugins/helm-s3 \

--- a/helm-push/entrypoint.sh
+++ b/helm-push/entrypoint.sh
@@ -28,5 +28,5 @@ fi
 helm lint $INPUT_CHART
 helm package $ARGS $INPUT_CHART
 
-helm2 repo add liatrio s3://${INPUT_BUCKET}/charts
-helm2 s3 push --force --acl="public-read" $(basename $INPUT_CHART)-${INPUT_VERSION}.tgz liatrio
+helm repo add liatrio s3://${INPUT_BUCKET}/charts
+helm s3 push --force --acl="public-read" $(basename $INPUT_CHART)-${INPUT_VERSION}.tgz liatrio

--- a/helm-push/entrypoint.sh
+++ b/helm-push/entrypoint.sh
@@ -29,7 +29,6 @@ helm lint $INPUT_CHART
 helm package $ARGS $INPUT_CHART
 
 helm repo add liatrio s3://${INPUT_BUCKET}/charts
-helm repo list
 helm env
-echo "$(basename $INPUT_CHART)-${INPUT_VERSION}.tgz"
+ln -s /github/home/.config/helm/repositories.yaml /root/.local/share/helm/repository/repositories.yaml
 helm s3 push --force --acl="public-read" $(basename $INPUT_CHART)-${INPUT_VERSION}.tgz liatrio

--- a/helm-push/entrypoint.sh
+++ b/helm-push/entrypoint.sh
@@ -30,8 +30,10 @@ helm package $ARGS $INPUT_CHART
 
 helm repo add liatrio s3://${INPUT_BUCKET}/charts
 helm env
+helm version --short --client
 pwd
 whoami
 mkdir -p /root/.local/share/helm/repository/
 ln -s /github/home/.config/helm/repositories.yaml /root/.local/share/helm/repository/repositories.yaml
+cat /github/home/.config/helm/repositories.yaml
 helm s3 push --force --acl="public-read" $(basename $INPUT_CHART)-${INPUT_VERSION}.tgz liatrio

--- a/helm-push/entrypoint.sh
+++ b/helm-push/entrypoint.sh
@@ -29,11 +29,4 @@ helm lint $INPUT_CHART
 helm package $ARGS $INPUT_CHART
 
 helm repo add liatrio s3://${INPUT_BUCKET}/charts
-helm env
-helm version --short --client
-pwd
-whoami
-mkdir -p /root/.local/share/helm/repository/
-ln -s /github/home/.config/helm/repositories.yaml /root/.local/share/helm/repository/repositories.yaml
-cat /github/home/.config/helm/repositories.yaml
 helm s3 push --force --acl="public-read" $(basename $INPUT_CHART)-${INPUT_VERSION}.tgz liatrio

--- a/helm-push/entrypoint.sh
+++ b/helm-push/entrypoint.sh
@@ -32,5 +32,6 @@ helm repo add liatrio s3://${INPUT_BUCKET}/charts
 helm env
 pwd
 whoami
+mkdir -p /root/.local/share/helm/repository/
 ln -s /github/home/.config/helm/repositories.yaml /root/.local/share/helm/repository/repositories.yaml
 helm s3 push --force --acl="public-read" $(basename $INPUT_CHART)-${INPUT_VERSION}.tgz liatrio

--- a/helm-push/entrypoint.sh
+++ b/helm-push/entrypoint.sh
@@ -30,5 +30,7 @@ helm package $ARGS $INPUT_CHART
 
 helm repo add liatrio s3://${INPUT_BUCKET}/charts
 helm env
+pwd
+whoami
 ln -s /github/home/.config/helm/repositories.yaml /root/.local/share/helm/repository/repositories.yaml
 helm s3 push --force --acl="public-read" $(basename $INPUT_CHART)-${INPUT_VERSION}.tgz liatrio

--- a/helm-push/entrypoint.sh
+++ b/helm-push/entrypoint.sh
@@ -30,4 +30,5 @@ helm package $ARGS $INPUT_CHART
 
 helm repo add liatrio s3://${INPUT_BUCKET}/charts
 helm repo list
+echo "$(basename $INPUT_CHART)-${INPUT_VERSION}.tgz"
 helm s3 push --force --acl="public-read" $(basename $INPUT_CHART)-${INPUT_VERSION}.tgz liatrio

--- a/helm-push/entrypoint.sh
+++ b/helm-push/entrypoint.sh
@@ -29,4 +29,5 @@ helm lint $INPUT_CHART
 helm package $ARGS $INPUT_CHART
 
 helm repo add liatrio s3://${INPUT_BUCKET}/charts
+helm repo list
 helm s3 push --force --acl="public-read" $(basename $INPUT_CHART)-${INPUT_VERSION}.tgz liatrio

--- a/helm-push/entrypoint.sh
+++ b/helm-push/entrypoint.sh
@@ -30,5 +30,6 @@ helm package $ARGS $INPUT_CHART
 
 helm repo add liatrio s3://${INPUT_BUCKET}/charts
 helm repo list
+helm env
 echo "$(basename $INPUT_CHART)-${INPUT_VERSION}.tgz"
 helm s3 push --force --acl="public-read" $(basename $INPUT_CHART)-${INPUT_VERSION}.tgz liatrio


### PR DESCRIPTION
- Updated ecr to use python3 rather than python2
- Updated helm-push to use the new stable source as the old source has been deprecated.