### PR TITLE
S3 push index fix

### DIFF
--- a/helm-push/entrypoint.sh
+++ b/helm-push/entrypoint.sh
@@ -29,4 +29,4 @@ helm lint $INPUT_CHART
 helm package $ARGS $INPUT_CHART
 
 helm repo add liatrio s3://${INPUT_BUCKET}/charts
-helm s3 push --force --acl="public-read" $(basename $INPUT_CHART)-${INPUT_VERSION}.tgz liatrio
+helm s3 push --force --relative --acl="public-read" $(basename $INPUT_CHART)-${INPUT_VERSION}.tgz liatrio && echo "s3 plugin push was successful" || echo "s3 plugin push failed"


### PR DESCRIPTION
Added the relative tag to the s3 push command because it was using the s3 address inside the s3 bucket's index.yaml file instead of using an http address. The relative address conceals the s3 address by truncating the address to just the tgz file at the end.

Example:
Original: s3://liatrio/example/example-file-v2.0.0.tgz
Relative: example-file-v2.0.0.tgz

Helm then handles the rest.

Echo statements were added to the end of the s3 push command because we discovered that github actions gets zero feedback when the push succeeds or fails.