### PR TITLE
fix: remove false as defaults, add --fail argument to curl request

### DIFF
--- a/github-create-release/action.yaml
+++ b/github-create-release/action.yaml
@@ -47,11 +47,11 @@ inputs:
     required: false
   draft:
     description: '`true` to create a draft(unpublished) release, false to create a published one'
-    default: ""
+    default: "false"
     required: false
   prerelease: 
     description: '`true` to identify the release as a prerelease. false to identify the release as a full release.'
-    default: ""
+    default: "false"
     required: false
   discussion_category_name:
     description: 'If specified, a discussion of the specified category is created and linked to the release. The value must be a category that already exists in the repository.'
@@ -59,5 +59,5 @@ inputs:
     required: false
   generate_release_notes:
     description: 'Whether to automatically generate the name and body for this release.'
-    default: ""
+    default: "false"
     required: false 

--- a/github-create-release/action.yaml
+++ b/github-create-release/action.yaml
@@ -47,11 +47,11 @@ inputs:
     required: false
   draft:
     description: '`true` to create a draft(unpublished) release, false to create a published one'
-    default: "false"
+    default: ""
     required: false
   prerelease: 
     description: '`true` to identify the release as a prerelease. false to identify the release as a full release.'
-    default: "false"
+    default: ""
     required: false
   discussion_category_name:
     description: 'If specified, a discussion of the specified category is created and linked to the release. The value must be a category that already exists in the repository.'
@@ -59,5 +59,5 @@ inputs:
     required: false
   generate_release_notes:
     description: 'Whether to automatically generate the name and body for this release.'
-    default: "false"
+    default: ""
     required: false 

--- a/github-create-release/action.yaml
+++ b/github-create-release/action.yaml
@@ -13,7 +13,7 @@ runs:
     DRAFT: ${{ inputs.draft }}
     PRERELEASE: ${{ inputs.prerelease }}
     DISCUSSION_CATEGORY_NAME: ${{ inputs.discussion_category_name }}
-    GENERAL_RELEASE_NOTES: ${{ inputs.generate_release_notes }}
+    GENERATE_RELEASE_NOTES: ${{ inputs.generate_release_notes }}
 
 description: 'Create a GitHub release'
 inputs: 

--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -8,6 +8,7 @@ curl \
   -H "Authorization: $TOKEN_NAME $PAT" \
   https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases \
   -d '{"'"tag_name"'":"'"$TAG_NAME"'", "'"name"'":"'"$NAME"'", "'"body"'":"'"$BODY"'", "'"draft"'":'$DRAFT', "'"prerelease"'":'$PRERELEASE', "'"discussion_category_name"'":"'"$DISCUSSION_CATEGORY_NAME"'",
-        "'"general_release_notes"'":'$GENERATE_RELEASE_NOTES'}'
+        "'"general_release_notes"'":'$GENERATE_RELEASE_NOTES'}' \
+  --false 
 
   

--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -5,8 +5,8 @@ curl \
   -X POST \
   -H "Authorization: $TOKEN_NAME $PAT" \
   https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases \
-  -d "{\"tag_name\":\"$TAG_NAME\", \"name\":\"$NAME\", \"body\":\"$BODY\", \"draft\": \"$DRAFT\", \"prerelease\":\"$PRERELEASE\", 
-        \"discussion_category_name\":\"$DISCUSSION_CATEGORY_NAME\", \"general_release_notes\": \"$GENERAL_RELEASE_NOTES\"}" \
+  -d "{\"tag_name\":\"$TAG_NAME\", \"name\":\"$NAME\", \"body\":\"$BODY\", \"draft\": $DRAFT, \"prerelease\": $PRERELEASE , 
+        \"discussion_category_name\":\"$DISCUSSION_CATEGORY_NAME\", \"general_release_notes\": $GENERAL_RELEASE_NOTES}" \
   --fail
 
   

--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -1,12 +1,11 @@
 #!/bin/sh -l
 
-
 curl \
   -X POST \
   -H "Authorization: $TOKEN_NAME $PAT" \
   https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases \
   -d "{\"tag_name\":\"$TAG_NAME\", \"name\":\"$NAME\", \"body\":\"$BODY\", \"draft\": $DRAFT, \"prerelease\": $PRERELEASE , 
-        \"discussion_category_name\":\"$DISCUSSION_CATEGORY_NAME\", \"general_release_notes\": $GENERAL_RELEASE_NOTES}" \
+        \"discussion_category_name\":\"$DISCUSSION_CATEGORY_NAME\", \"general_release_notes\": $GENERATE_RELEASE_NOTES}" \
   --fail
 
   

--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -1,8 +1,4 @@
 #!/bin/sh -l
-echo "Draft: $DRAFT"
-echo "Prerelease: $PRERELEASE"
-echo "Generate_Release_Notes: $GENERATE_RELEASE_NOTES"
-echo "Tag_name: $TAG_NAME"
 curl \
   -X POST \
   -H "Authorization: $TOKEN_NAME $PAT" \

--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -2,6 +2,7 @@
 echo "Draft: $DRAFT"
 echo "Prerelease: $PRERELEASE"
 echo "Generate_Release_Notes: $GENERATE_RELEASE_NOTES"
+echo "Tag_name: $TAG_NAME"
 curl \
   -X POST \
   -H "Authorization: $TOKEN_NAME $PAT" \

--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -4,7 +4,7 @@ curl \
   -X POST \
   -H "Authorization: $TOKEN_NAME $PAT" \
   https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases \
-  -d "{\"tag_name\":\"$TAG_NAME\", \"name\":\"$NAME\", \"body\":\"$BODY\", \"draft\": $DRAFT, \"prerelease\": $PRERELEASE , 
-        \"discussion_category_name\":\"$DISCUSSION_CATEGORY_NAME\", \"general_release_notes\": $GENERATE_RELEASE_NOTES}" 
+  -d "{\"tag_name\":\"$TAG_NAME\", \"name\":\"$NAME\", \"body\":\"$BODY\", \"draft\": '$DRAFT', \"prerelease\": '$PRERELEASE' , 
+        \"discussion_category_name\":\"$DISCUSSION_CATEGORY_NAME\", \"general_release_notes\": '$GENERATE_RELEASE_NOTES'}" 
 
   

--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -8,7 +8,6 @@ curl \
   -H "Authorization: $TOKEN_NAME $PAT" \
   https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases \
   -d '{"'"tag_name"'":"'"$TAG_NAME"'", "'"name"'":"'"$NAME"'", "'"body"'":"'"$BODY"'", "'"draft"'":'$DRAFT', "'"prerelease"'":'$PRERELEASE', "'"discussion_category_name"'":"'"$DISCUSSION_CATEGORY_NAME"'",
-        "'"general_release_notes"'":'$GENERATE_RELEASE_NOTES'}' \
-  --fail
+        "'"general_release_notes"'":'$GENERATE_RELEASE_NOTES'}'
 
   

--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -6,7 +6,10 @@ curl \
   -X POST \
   -H "Authorization: $TOKEN_NAME $PAT" \
   https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases \
-  -d "{\"tag_name\":\"$TAG_NAME\", \"name\":\"$NAME\", \"body\":\"$BODY\", \"draft\": \"'$DRAFT'\", \"prerelease\": \"'$PRERELEASE'\" , 
-        \"discussion_category_name\":\"$DISCUSSION_CATEGORY_NAME\", \"general_release_notes\": \"'$GENERATE_RELEASE_NOTES'\"}" 
+  -d '{"'"tag_name"'":"'"$TAG_NAME"'", "'"name"'":"'"$NAME"'", "'"body"'":"'"$BODY"'", "'"draft"'":'$DRAFT', "'"prerelease"'":'$PRERELEASE', "'"discussion_category_name"'":"'"$DISCUSSION_CATEGORY_NAME"'",
+        "'"general_release_notes"'":'$GENERATE_RELEASE_NOTES'}'
+
+  #"{\"tag_name\":\"$TAG_NAME\", \"name\":\"$NAME\", \"body\":\"$BODY\", \"draft\": \"'$DRAFT'\", \"prerelease\": \"'$PRERELEASE'\" , 
+  #      \"discussion_category_name\":\"$DISCUSSION_CATEGORY_NAME\", \"general_release_notes\": \"'$GENERATE_RELEASE_NOTES'\"}" 
 
   

--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -5,7 +5,6 @@ curl \
   -H "Authorization: $TOKEN_NAME $PAT" \
   https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases \
   -d "{\"tag_name\":\"$TAG_NAME\", \"name\":\"$NAME\", \"body\":\"$BODY\", \"draft\": $DRAFT, \"prerelease\": $PRERELEASE , 
-        \"discussion_category_name\":\"$DISCUSSION_CATEGORY_NAME\", \"general_release_notes\": $GENERATE_RELEASE_NOTES}" \
-  --fail
+        \"discussion_category_name\":\"$DISCUSSION_CATEGORY_NAME\", \"general_release_notes\": $GENERATE_RELEASE_NOTES}" 
 
   

--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -1,10 +1,12 @@
 #!/bin/sh -l
-
+echo "Draft: $DRAFT"
+echo "Prerelease: $PRERELEASE"
+echo "Generate_Release_Notes: $GENERATE_RELEASE_NOTES"
 curl \
   -X POST \
   -H "Authorization: $TOKEN_NAME $PAT" \
   https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases \
-  -d "{\"tag_name\":\"$TAG_NAME\", \"name\":\"$NAME\", \"body\":\"$BODY\", \"draft\": '$DRAFT', \"prerelease\": '$PRERELEASE' , 
-        \"discussion_category_name\":\"$DISCUSSION_CATEGORY_NAME\", \"general_release_notes\": '$GENERATE_RELEASE_NOTES'}" 
+  -d "{\"tag_name\":\"$TAG_NAME\", \"name\":\"$NAME\", \"body\":\"$BODY\", \"draft\": \"'$DRAFT'\", \"prerelease\": \"'$PRERELEASE'\" , 
+        \"discussion_category_name\":\"$DISCUSSION_CATEGORY_NAME\", \"general_release_notes\": \"'$GENERATE_RELEASE_NOTES'\"}" 
 
   

--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -8,9 +8,7 @@ curl \
   -H "Authorization: $TOKEN_NAME $PAT" \
   https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases \
   -d '{"'"tag_name"'":"'"$TAG_NAME"'", "'"name"'":"'"$NAME"'", "'"body"'":"'"$BODY"'", "'"draft"'":'$DRAFT', "'"prerelease"'":'$PRERELEASE', "'"discussion_category_name"'":"'"$DISCUSSION_CATEGORY_NAME"'",
-        "'"general_release_notes"'":'$GENERATE_RELEASE_NOTES'}'
-
-  #"{\"tag_name\":\"$TAG_NAME\", \"name\":\"$NAME\", \"body\":\"$BODY\", \"draft\": \"'$DRAFT'\", \"prerelease\": \"'$PRERELEASE'\" , 
-  #      \"discussion_category_name\":\"$DISCUSSION_CATEGORY_NAME\", \"general_release_notes\": \"'$GENERATE_RELEASE_NOTES'\"}" 
+        "'"general_release_notes"'":'$GENERATE_RELEASE_NOTES'}' \
+  --fail
 
   

--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -5,6 +5,6 @@ curl \
   https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases \
   -d '{"'"tag_name"'":"'"$TAG_NAME"'", "'"name"'":"'"$NAME"'", "'"body"'":"'"$BODY"'", "'"draft"'":'$DRAFT', "'"prerelease"'":'$PRERELEASE', "'"discussion_category_name"'":"'"$DISCUSSION_CATEGORY_NAME"'",
         "'"general_release_notes"'":'$GENERATE_RELEASE_NOTES'}' \
-  --false 
+  --fail
 
   

--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -6,6 +6,7 @@ curl \
   -H "Authorization: $TOKEN_NAME $PAT" \
   https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases \
   -d "{\"tag_name\":\"$TAG_NAME\", \"name\":\"$NAME\", \"body\":\"$BODY\", \"draft\": \"$DRAFT\", \"prerelease\":\"$PRERELEASE\", 
-        \"discussion_category_name\":\"$DISCUSSION_CATEGORY_NAME\", \"general_release_notes\": \"$GENERAL_RELEASE_NOTES\"}" 
+        \"discussion_category_name\":\"$DISCUSSION_CATEGORY_NAME\", \"general_release_notes\": \"$GENERAL_RELEASE_NOTES\"}" \
+  --fail
 
   

--- a/github-upload-asset/action.yaml
+++ b/github-upload-asset/action.yaml
@@ -33,5 +33,5 @@ inputs:
 
   RELEASE:
     description: 'Release name'
-    default: 'Latest'
+    default: 'latest'
     required: false

--- a/github-upload-asset/action.yaml
+++ b/github-upload-asset/action.yaml
@@ -3,7 +3,7 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   env: 
-    GITHUB_REPOSITORY: ${{ inputs.GITHUB_REPOSITORY }}
+    GITHUB_REPO: ${{ inputs.GITHUB_REPOSITORY }}
     GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
     ORG_OWNER: ${{ inputs.ORG_OWNER }}
     RELEASE: ${{ inputs.RELEASE }}
@@ -16,7 +16,7 @@ inputs:
     default: ""
     required: true
 
-  GITHUB_REPOSITORY: 
+  GITHUB_REPO: 
     description: 'Github repo name'
     default: ""
     required: true

--- a/github-upload-asset/action.yaml
+++ b/github-upload-asset/action.yaml
@@ -33,5 +33,5 @@ inputs:
 
   RELEASE:
     description: 'Release name'
-    default: 'latest'
+    default: 'Latest'
     required: false

--- a/github-upload-asset/action.yaml
+++ b/github-upload-asset/action.yaml
@@ -3,7 +3,7 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   env: 
-    GITHUB_REPO: ${{ inputs.GITHUB_REPOSITORY }}
+    REPO: ${{ inputs.REPO }}
     GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
     ORG_OWNER: ${{ inputs.ORG_OWNER }}
     RELEASE: ${{ inputs.RELEASE }}
@@ -16,7 +16,7 @@ inputs:
     default: ""
     required: true
 
-  GITHUB_REPO: 
+  REPO: 
     description: 'Github repo name'
     default: ""
     required: true

--- a/github-upload-asset/entrypoint.sh
+++ b/github-upload-asset/entrypoint.sh
@@ -19,4 +19,4 @@ curl \
     -H "Content-Type:application/octet-stream" \
     --upload-file "${FILE}" \
     ${UPLOAD_URL} \
-    --false
+    --fail

--- a/github-upload-asset/entrypoint.sh
+++ b/github-upload-asset/entrypoint.sh
@@ -9,9 +9,8 @@ curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${
 RELEASE_ID=$(jq --raw-output '.id' "temp.json")
 echo "RELEASE_ID: ${RELEASE_ID}"
 
-tmp=${mktemp}
 
-UPLOAD_URL="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${FILE}"
+UPLOAD_URL="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${FILENAME}"
 echo "UPLOAD_URL: ${UPLOAD_URL}"
 
 curl \

--- a/github-upload-asset/entrypoint.sh
+++ b/github-upload-asset/entrypoint.sh
@@ -7,10 +7,10 @@ echo "FILE: ${FILENAME}"
 curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${ORG_OWNER}/${GITHUB_REPOSITORY}/releases/${RELEASE} > temp.json
 
 RELEASE_ID=$(jq --raw-output '.id' "temp.json")
-echo "RELEASE_ID: ${RELEASE_ID}"
+echo "RELEASE_ID: ${RELEASE}"
 
 
-UPLOAD_URL="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${FILENAME}"
+UPLOAD_URL="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE}/assets?name=${FILENAME}"
 echo "UPLOAD_URL: ${UPLOAD_URL}"
 
 curl \

--- a/github-upload-asset/entrypoint.sh
+++ b/github-upload-asset/entrypoint.sh
@@ -3,17 +3,17 @@
 FILENAME=$(basename "${FILE}")
 echo "FILE: ${FILENAME}"
 echo "ORG_OWNER: ${ORG_OWNER}"
-echo "GITHUB_REPOSITORY: ${GITHUB_RESPOSITORY}"
+echo "GITHUB_REPOSITORY: ${GITHUB_REPOS}"
 
 # Get the latest release id, store in temporary file
-curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${ORG_OWNER}/${GITHUB_REPOSITORY}/releases/latest > temp.json
+curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${ORG_OWNER}/${GITHUB_REPO}/releases/latest > temp.json
 
 
 RELEASE_ID=$(jq --raw-output '.id' "temp.json")
 echo "RELEASE_ID: ${RELEASE_ID}"
 
 
-UPLOAD_URL="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${FILENAME}"
+UPLOAD_URL="https://uploads.github.com/repos/${GITHUB_REPO}/releases/${RELEASE_ID}/assets?name=${FILENAME}"
 echo "UPLOAD_URL: ${UPLOAD_URL}"
 
 curl \

--- a/github-upload-asset/entrypoint.sh
+++ b/github-upload-asset/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/sh -l
 
 FILENAME=$(basename "${FILE}")
-echo "GITHUB_REPOSITORY: ${REPO}"
 
 # Get the latest release id, store in temporary file
 curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${ORG_OWNER}/${REPO}/releases/latest > temp.json

--- a/github-upload-asset/entrypoint.sh
+++ b/github-upload-asset/entrypoint.sh
@@ -7,10 +7,10 @@ echo "FILE: ${FILENAME}"
 curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${ORG_OWNER}/${GITHUB_REPOSITORY}/releases/${RELEASE} > temp.json
 
 RELEASE_ID=$(jq --raw-output '.id' "temp.json")
-echo "RELEASE_ID: ${RELEASE}"
+echo "RELEASE_ID: ${RELEASE_ID}"
 
 
-UPLOAD_URL="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE}/assets?name=${FILENAME}"
+UPLOAD_URL="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${FILENAME}"
 echo "UPLOAD_URL: ${UPLOAD_URL}"
 
 curl \

--- a/github-upload-asset/entrypoint.sh
+++ b/github-upload-asset/entrypoint.sh
@@ -2,9 +2,10 @@
 
 FILENAME=$(basename "${FILE}")
 echo "FILE: ${FILENAME}"
-
+echo "OWNER: ${OWNER}"
+echo "GITHUB_REPOSITORY: ${GITHUB_REPOSITORY}"
 # Get the latest release id, store in temporary file
-curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${ORG_OWNER}/${GITHUB_REPOSITORY}/releases/latest > temp.json
+curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/liatrio/mobile-pipeline-poc/releases/latest > temp.json
 
 cat temp.json
 

--- a/github-upload-asset/entrypoint.sh
+++ b/github-upload-asset/entrypoint.sh
@@ -4,7 +4,7 @@ FILENAME=$(basename "${FILE}")
 echo "FILE: ${FILENAME}"
 
 # Get the latest release id, store in temporary file
-curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${ORG_OWNER}/${GITHUB_REPOSITORY}/releases/${RELEASE} > temp.json
+curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${ORG_OWNER}/${GITHUB_REPOSITORY}/releases/latest > temp.json
 
 cat temp.json
 

--- a/github-upload-asset/entrypoint.sh
+++ b/github-upload-asset/entrypoint.sh
@@ -2,12 +2,10 @@
 
 FILENAME=$(basename "${FILE}")
 echo "FILE: ${FILENAME}"
-echo "OWNER: ${OWNER}"
-echo "GITHUB_REPOSITORY: ${GITHUB_REPOSITORY}"
-# Get the latest release id, store in temporary file
-curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/liatrio/mobile-pipeline-poc/releases/latest > temp.json
 
-cat temp.json
+# Get the latest release id, store in temporary file
+curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${ORG_OWNER}/${GITHUB_REPOSITORY}/releases/latest > temp.json
+
 
 RELEASE_ID=$(jq --raw-output '.id' "temp.json")
 echo "RELEASE_ID: ${RELEASE_ID}"

--- a/github-upload-asset/entrypoint.sh
+++ b/github-upload-asset/entrypoint.sh
@@ -19,4 +19,4 @@ curl \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Content-Type:application/octet-stream" \
     --upload-file "${FILE}" \
-    ${UPLOAD_URL}
+    ${UPLOAD_URL} 

--- a/github-upload-asset/entrypoint.sh
+++ b/github-upload-asset/entrypoint.sh
@@ -2,6 +2,8 @@
 
 FILENAME=$(basename "${FILE}")
 echo "FILE: ${FILENAME}"
+echo "ORG_OWNER: ${ORG_OWNER}"
+echo "GITHUB_REPOSITORY: ${GITHUB_RESPOSITORY}"
 
 # Get the latest release id, store in temporary file
 curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${ORG_OWNER}/${GITHUB_REPOSITORY}/releases/latest > temp.json

--- a/github-upload-asset/entrypoint.sh
+++ b/github-upload-asset/entrypoint.sh
@@ -3,7 +3,7 @@
 FILENAME=$(basename "${FILE}")
 
 # Get the latest release id, store in temporary file
-curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${ORG_OWNER}/${REPO}/releases/latest > temp.json
+curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${ORG_OWNER}/${REPO}/releases/${RELEASE} > temp.json
 
 
 RELEASE_ID=$(jq --raw-output '.id' "temp.json")

--- a/github-upload-asset/entrypoint.sh
+++ b/github-upload-asset/entrypoint.sh
@@ -6,6 +6,8 @@ echo "FILE: ${FILENAME}"
 # Get the latest release id, store in temporary file
 curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${ORG_OWNER}/${GITHUB_REPOSITORY}/releases/${RELEASE} > temp.json
 
+cat temp.json
+
 RELEASE_ID=$(jq --raw-output '.id' "temp.json")
 echo "RELEASE_ID: ${RELEASE_ID}"
 

--- a/github-upload-asset/entrypoint.sh
+++ b/github-upload-asset/entrypoint.sh
@@ -11,7 +11,7 @@ RELEASE_ID=$(jq --raw-output '.id' "temp.json")
 echo "RELEASE_ID: ${RELEASE_ID}"
 
 
-UPLOAD_URL="https://uploads.github.com/repos/${REPO}/releases/${RELEASE_ID}/assets?name=${FILENAME}"
+UPLOAD_URL="https://uploads.github.com/repos/${ORG_OWNER}/${REPO}/releases/${RELEASE_ID}/assets?name=${FILENAME}"
 echo "UPLOAD_URL: ${UPLOAD_URL}"
 
 curl \

--- a/github-upload-asset/entrypoint.sh
+++ b/github-upload-asset/entrypoint.sh
@@ -1,12 +1,10 @@
 #!/bin/sh -l
 
 FILENAME=$(basename "${FILE}")
-echo "FILE: ${FILENAME}"
-echo "ORG_OWNER: ${ORG_OWNER}"
-echo "GITHUB_REPOSITORY: ${GITHUB_REPO}"
+echo "GITHUB_REPOSITORY: ${REPO}"
 
 # Get the latest release id, store in temporary file
-curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${ORG_OWNER}/${GITHUB_REPO}/releases/latest > temp.json
+curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${ORG_OWNER}/${REPO}/releases/latest > temp.json
 
 
 RELEASE_ID=$(jq --raw-output '.id' "temp.json")

--- a/github-upload-asset/entrypoint.sh
+++ b/github-upload-asset/entrypoint.sh
@@ -11,7 +11,7 @@ RELEASE_ID=$(jq --raw-output '.id' "temp.json")
 echo "RELEASE_ID: ${RELEASE_ID}"
 
 
-UPLOAD_URL="https://uploads.github.com/repos/${GITHUB_REPO}/releases/${RELEASE_ID}/assets?name=${FILENAME}"
+UPLOAD_URL="https://uploads.github.com/repos/${REPO}/releases/${RELEASE_ID}/assets?name=${FILENAME}"
 echo "UPLOAD_URL: ${UPLOAD_URL}"
 
 curl \

--- a/github-upload-asset/entrypoint.sh
+++ b/github-upload-asset/entrypoint.sh
@@ -3,7 +3,7 @@
 FILENAME=$(basename "${FILE}")
 echo "FILE: ${FILENAME}"
 echo "ORG_OWNER: ${ORG_OWNER}"
-echo "GITHUB_REPOSITORY: ${GITHUB_REPOS}"
+echo "GITHUB_REPOSITORY: ${GITHUB_REPO}"
 
 # Get the latest release id, store in temporary file
 curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${ORG_OWNER}/${GITHUB_REPO}/releases/latest > temp.json

--- a/github-upload-asset/entrypoint.sh
+++ b/github-upload-asset/entrypoint.sh
@@ -19,4 +19,5 @@ curl \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Content-Type:application/octet-stream" \
     --upload-file "${FILE}" \
-    ${UPLOAD_URL} 
+    ${UPLOAD_URL} \
+    --false


### PR DESCRIPTION
github-create-release
----------------------
- add --fail flag to curl request
- Refactor data portion of curl request to incorporate boolean variables `DRAFT` , `PRERELEASE` , and `$GENERATE_RELEASE_NOTES` . 

github-upload-asset
---------------------
- In action.yaml replace GITHUB_REPOSITORY  with REPO. GITHUB_REPOSITORY is a default env variable in github actions [](https://docs.github.com/en/actions/learn-github-actions/environment-variables )
- add `ORG_OWNER` to `UPLOAD_URL` in entrypoint.sh
- Fix syntax/spelling errors in the enttrypoint.sh
- add --fail flag to curl request 