### PR TITLE
fix: remove discussion_category_name from entrypoint script 

### DIFF
--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -3,7 +3,7 @@ curl \
   -X POST \
   -H "Authorization: $TOKEN_NAME $PAT" \
   https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases \
-  --fail
+  --fail \
   -d '{"'"tag_name"'":"'"$TAG_NAME"'", "'"name"'":"'"$NAME"'", "'"body"'":"'"$BODY"'", "'"draft"'":'$DRAFT', "'"prerelease"'":'$PRERELEASE', "'"discussion_category_name"'":"'"$DISCUSSION_CATEGORY_NAME"'",
         "'"generate_release_notes"'":'$GENERATE_RELEASE_NOTES'}'  
  # -v 

--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -5,6 +5,8 @@ curl \
   https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases \
   -d '{"'"tag_name"'":"'"$TAG_NAME"'", "'"name"'":"'"$NAME"'", "'"body"'":"'"$BODY"'", "'"draft"'":'$DRAFT', "'"prerelease"'":'$PRERELEASE', "'"discussion_category_name"'":"'"$DISCUSSION_CATEGORY_NAME"'",
         "'"generate_release_notes"'":'$GENERATE_RELEASE_NOTES'}' \
-  --fail
+  --fail \
+  -v \
+  --trace 
 
   

--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -3,9 +3,9 @@ curl \
   -X POST \
   -H "Authorization: $TOKEN_NAME $PAT" \
   https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases \
+  --fail
   -d '{"'"tag_name"'":"'"$TAG_NAME"'", "'"name"'":"'"$NAME"'", "'"body"'":"'"$BODY"'", "'"draft"'":'$DRAFT', "'"prerelease"'":'$PRERELEASE', "'"discussion_category_name"'":"'"$DISCUSSION_CATEGORY_NAME"'",
-        "'"generate_release_notes"'":'$GENERATE_RELEASE_NOTES'}' \
- # --fail \
+        "'"generate_release_notes"'":'$GENERATE_RELEASE_NOTES'}'  
  # -v 
 
   

--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -3,9 +3,8 @@ curl \
   -X POST \
   -H "Authorization: $TOKEN_NAME $PAT" \
   https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases \
-  --fail-early \
-  -d '{"'"tag_name"'":"'"$TAG_NAME"'", "'"name"'":"'"$NAME"'", "'"body"'":"'"$BODY"'", "'"draft"'":'$DRAFT', "'"prerelease"'":'$PRERELEASE', "'"discussion_category_name"'":"'"$DISCUSSION_CATEGORY_NAME"'",
-        "'"generate_release_notes"'":'$GENERATE_RELEASE_NOTES'}'  
- # -v 
+  -d '{"'"tag_name"'":"'"$TAG_NAME"'", "'"name"'":"'"$NAME"'", "'"body"'":"'"$BODY"'", "'"draft"'":'$DRAFT', "'"prerelease"'":'$PRERELEASE',
+        "'"generate_release_notes"'":'$GENERATE_RELEASE_NOTES'}' \
+  --fail
 
   

--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -6,7 +6,6 @@ curl \
   -d '{"'"tag_name"'":"'"$TAG_NAME"'", "'"name"'":"'"$NAME"'", "'"body"'":"'"$BODY"'", "'"draft"'":'$DRAFT', "'"prerelease"'":'$PRERELEASE', "'"discussion_category_name"'":"'"$DISCUSSION_CATEGORY_NAME"'",
         "'"generate_release_notes"'":'$GENERATE_RELEASE_NOTES'}' \
   --fail \
-  -v \
-  --trace 
+  -v 
 
   

--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -5,7 +5,7 @@ curl \
   https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases \
   -d '{"'"tag_name"'":"'"$TAG_NAME"'", "'"name"'":"'"$NAME"'", "'"body"'":"'"$BODY"'", "'"draft"'":'$DRAFT', "'"prerelease"'":'$PRERELEASE', "'"discussion_category_name"'":"'"$DISCUSSION_CATEGORY_NAME"'",
         "'"generate_release_notes"'":'$GENERATE_RELEASE_NOTES'}' \
-  --fail \
-  -v 
+ # --fail \
+ # -v 
 
   

--- a/github-create-release/entrypoint.sh
+++ b/github-create-release/entrypoint.sh
@@ -3,7 +3,7 @@ curl \
   -X POST \
   -H "Authorization: $TOKEN_NAME $PAT" \
   https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases \
-  --fail \
+  --fail-early \
   -d '{"'"tag_name"'":"'"$TAG_NAME"'", "'"name"'":"'"$NAME"'", "'"body"'":"'"$BODY"'", "'"draft"'":'$DRAFT', "'"prerelease"'":'$PRERELEASE', "'"discussion_category_name"'":"'"$DISCUSSION_CATEGORY_NAME"'",
         "'"generate_release_notes"'":'$GENERATE_RELEASE_NOTES'}'  
  # -v 


### PR DESCRIPTION
- Removing `discussion_category_name` because if it is specified the value must be a category that already exists in the repo. If it is not there, it will return a status: 404 error not found, causing the `--fail` flag of our curl request to fail [https://docs.github.com/en/rest/reference/repos#create-a-release](url)
- Leaving it in the action.yaml in case it could be used in the future. 