### PR TITLE
feat: allow the `chore` prefix for contentional-pr-title action

### DIFF
--- a/conventional-pr-title/action.yml
+++ b/conventional-pr-title/action.yml
@@ -18,6 +18,7 @@ inputs:
       build
       ci
       revert
+      chore
 runs:
   using: docker
   image: docker://ghcr.io/liatrio/github-actions/conventional-pr-title:latest


### PR DESCRIPTION
we originally excluded this prefix because we were worried that "chore" would be more of a catch-all that people would use by default instead of really thinking about which prefix to use.  however, dependabot's PRs use this prefix, which means we can't use dependabot as long as this action forbids chore.  so I'm adding it back to the list of allowed prefixes.