### PR TITLE
feat: add apprentice-action to workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
     paths:
+      - 'apprentice-action/**'
       - 'conventional-release/**'
       - 'conventional-pr-title/**'
       - '.github/workflows/build.yaml'
@@ -14,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        action: ['conventional-release', 'conventional-pr-title']
+        action: ['conventional-release', 'conventional-pr-title', 'apprentice-action']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/apprentice-action/Dockerfile
+++ b/apprentice-action/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_TAG=14-alpine
+ARG NODE_TAG=16-alpine
 FROM node:${NODE_TAG} as builder
 WORKDIR /action
 COPY package.json yarn.lock ./

--- a/apprentice-action/tests/endpoint.test.js
+++ b/apprentice-action/tests/endpoint.test.js
@@ -19,7 +19,7 @@ describe("Tests to the \"/\" endpoint", () => {
 
     it("should return a Message saying \"My name is ...\"", async () => {
         const res = await axios("http://host.docker.internal:80/");
-        expect(res.data.Message).to.contain("My name is");
+        expect(res.data.message).to.contain("My name is");
     });
 
     it("should return a UNIX style timestamp (numerical values only)", async () => {


### PR DESCRIPTION
fix: We're also updating the alpine version and a unit test in the PR
- Eslint sent an error at runtime about our version of alpine we were using
- I also ran into the error of the `message` the unit test was looking for was `Message`. I changed it to lowercase to match wth `timestamp`