### PR TITLE
fix: update action.yml in Conventional Release

### DIFF
--- a/conventional-release/action.yml
+++ b/conventional-release/action.yml
@@ -9,6 +9,9 @@ inputs:
     description: "Controls if semantic-release performs the release"
     required: false
     default: ""
+outputs:
+  newVersion:
+    description: "The new version tag outputted by Semantic Release"
 runs:
   using: "composite"
   steps:

--- a/conventional-release/action.yml
+++ b/conventional-release/action.yml
@@ -28,4 +28,3 @@ runs:
       env:
         DEBUG: ${{ inputs.debug }}
         DRY_RUN: ${{ inputs.dryRun }}
-        


### PR DESCRIPTION
The Conventional Release action sets the `newVersion` output, but it was not set in the `action.yaml` file. @austinjw and I believe that this caused a problem accessing the set output in later actions.