### PR TITLE
fix: add value section to outputs and id to entryoint step

### DIFF
--- a/conventional-release/action.yml
+++ b/conventional-release/action.yml
@@ -12,6 +12,7 @@ inputs:
 outputs:
   newVersion:
     description: "The new version tag outputted by Semantic Release"
+    value: ${{ steps.entrypoint.outputs.newVersion }}
 runs:
   using: "composite"
   steps:
@@ -24,6 +25,7 @@ runs:
     - run: cd $GITHUB_ACTION_PATH && yarn install --production
       shell: bash
     - run: $GITHUB_ACTION_PATH/entrypoint.sh
+      id: entrypoint
       shell: bash
       env:
         DEBUG: ${{ inputs.debug }}


### PR DESCRIPTION
We forgot to add the value line of the outputs section because this is a composite action and it's weird. See weirdness on this actions [documentation page](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action#creating-an-action-metadata-file).