### PR TITLE
fix: add changed output to conventional-release

### DIFF
--- a/conventional-release/action.yml
+++ b/conventional-release/action.yml
@@ -13,6 +13,9 @@ outputs:
   newVersion:
     description: "The new version tag outputted by Semantic Release"
     value: ${{ steps.entrypoint.outputs.newVersion }}
+  changed:
+    description: "A bool stating if there is a new release or not."
+    value: ${{ steps.entrypoint.outputs.changed }}
 runs:
   using: "composite"
   steps:

--- a/conventional-release/action.yml
+++ b/conventional-release/action.yml
@@ -14,7 +14,7 @@ outputs:
     description: "The new version tag outputted by Semantic Release"
     value: ${{ steps.entrypoint.outputs.newVersion }}
   changed:
-    description: "A bool stating if there is a new release or not."
+    description: "A string stating if there is a new release or not."
     value: ${{ steps.entrypoint.outputs.changed }}
 runs:
   using: "composite"


### PR DESCRIPTION
Previously, Austin Micah and I added the `newVersion` output, but we didn't add the `changed` output. This PR allows the `changed` output to be accessed.
