### PR TITLE
fix: add check for previous tag existence in entrypoint.sh

### DIFF
--- a/conventional-release/entrypoint.sh
+++ b/conventional-release/entrypoint.sh
@@ -18,10 +18,10 @@ fi
 
 #Check to see if a previous tag exists
 if previousVersion=$(git describe --tags --abbrev=0 2>/dev/null); then
-  echo "A previos tag was found"
+  echo "A previous tag was found"
   output "previousVersion" "${previousVersion}"
 else
-  echo "A previos tag was not found"
+  echo "A previous tag was not found"
 fi
 
 $GITHUB_ACTION_PATH/node_modules/semantic-release/bin/semantic-release.js "${flags[@]}"

--- a/conventional-release/entrypoint.sh
+++ b/conventional-release/entrypoint.sh
@@ -16,8 +16,13 @@ if [ "${DEBUG}" ]; then
   flags+=(--debug)
 fi
 
-previousVersion=$(git describe --tags --abbrev=0)
-output "previousVersion" "${previousVersion}"
+#Check to see if a previous tag exists
+if previousVersion=$(git describe --tags --abbrev=0 2>/dev/null); then
+  echo "A previos tag was found"
+  output "previousVersion" "${previousVersion}"
+else
+  echo "A previos tag was not found"
+fi
 
 $GITHUB_ACTION_PATH/node_modules/semantic-release/bin/semantic-release.js "${flags[@]}"
 


### PR DESCRIPTION
Fix a bug found on the code. The script was crashing if the repo did not have an existing tag.