### PR TITLE
Completed json minification check in apprentice-action tests

### DIFF
--- a/apprentice-action/tests/endpoint.test.js
+++ b/apprentice-action/tests/endpoint.test.js
@@ -33,8 +33,8 @@ describe("Tests to the \"/\" endpoint", () => {
         expect(res.data.timestamp).to.be.within(now - 5000, now);
     });
     it("should return a minified JSON object.", async () => {
-        const res = await axios(`http://${dockerBridgeIP}:80/`);
-        // TODO: Finish this test
-        throw new Error("TypeError: Object(...) is not a function");
+        const res = await axios(`http://${dockerBridgeIP}:80/`, {transformResponse: [(data) => data]});
+        const withoutQuotes = res.data.replace(/"[^"]*"/g, '""');
+        expect(withoutQuotes).to.not.match(/\s/);
     });
 });


### PR DESCRIPTION
I couldn't figure out how to suppress test 7. Forked it and completed the todo.

The finished test transforms the json string into raw data in the axios get request, then removes all characters enclosed in quotation marks. The expect statement checks if the remaining data does not match a pattern containing any whitespace characters.